### PR TITLE
Update install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -625,6 +625,7 @@ services:
    - NET_ADMIN
   volumes:
    - /DNIF/LC:/dnif/lc
+   - /DNIF/backup/lc:/backup
   container_name: console-v9">/DNIF/LC/docker-compose.yaml
 						cd /DNIF/LC || exit
 						echo -e "\n[-] Starting container... \n"
@@ -939,6 +940,7 @@ services:
    - NET_ADMIN
   volumes:
    - /DNIF/LC:/dnif/lc
+   - /DNIF/backup/lc:/backup
   container_name: console-v9">/DNIF/LC/podman-compose.yaml
 						echo -e "\n[-] Starting container... \n"
 						cd /DNIF/LC


### PR DESCRIPTION
Added persistent LC backup volume to console docker-compose configuration by including: /DNIF/backup/lc:/backup
This ensures LC backups are stored persistently on disk.